### PR TITLE
Improve override functions inside of compile_skillet_dict

### DIFF
--- a/example_skillets/skillet_includes/check_zones.skillet.yaml
+++ b/example_skillets/skillet_includes/check_zones.skillet.yaml
@@ -8,14 +8,14 @@ description: |
 type: pan_validation
 labels:
   collection:
-    - Example Skillets
-    - Validation
+    - Test Skillets
 
 variables:
   - name: zone_to_test
     description: Name of the Zone to test
     default: internet
     type_hint: text
+
   - name: interface_to_test
     description: Name of the Interface to test
     default: ethernet1/1

--- a/example_skillets/skillet_includes/include_other_skillets.skillet.yaml
+++ b/example_skillets/skillet_includes/include_other_skillets.skillet.yaml
@@ -15,6 +15,15 @@ variables:
     default: test123456
     type_hint: text
 
+  # When variables are duplicated or shared within all children skillets, overriding the variable attributes in one snippet
+  # can affect how the variable is brought into another child snippet. In certain scenarios when you want to preserve one
+  # child's variable definition and have it override all other definitions, you can bring the variable into the parents'
+  # variable section to set the variable definition, not applying any child overrides.
+  - name: shared_base_variable
+    description: Random variable shared with all children skillets
+    default: test123456
+    type_hint: text
+
 snippets:
   - name: parse_config
     cmd: parse
@@ -59,12 +68,24 @@ snippets:
       - name: zone_to_test
         default: untrust
 
-  - name: Final Include
+  - name: Include some more
     include: qos_class
     # You may sometimes which to include all variables, but override certain attributes of all of them. This example
-    # will include all variables, and add / override the toggle_hint attribute for each of them
+    # will include all variables, and add / override the toggle_hint attribute for each of them. This is really helpful
+    # when the snippet is executed conditionally with a when statement because you will only want to include these specific
+    # variables when the snippet is meant to be executed.
     include_variables:
       - name: all
         toggle_hint:
           source: zone_to_test
           value: untrust
+
+  - name: Final Include
+    include: logging_status
+    # When children override the same variable (for this example, it is the qos_class variable), the properties get merged
+    # from all included variables.
+    include_variables:
+      - name: all
+        toggle_hint:
+          source: zone_to_test
+          value: internet

--- a/example_skillets/skillet_includes/include_other_skillets.skillet.yaml
+++ b/example_skillets/skillet_includes/include_other_skillets.skillet.yaml
@@ -78,7 +78,8 @@ snippets:
       - name: all
         toggle_hint:
           source: zone_to_test
-          value: untrust
+          value:
+            - untrust
 
   - name: Final Include
     include: logging_status
@@ -88,4 +89,5 @@ snippets:
       - name: all
         toggle_hint:
           source: zone_to_test
-          value: internet
+          value:
+            - internet

--- a/example_skillets/skillet_includes/logging_status.skillet.yaml
+++ b/example_skillets/skillet_includes/logging_status.skillet.yaml
@@ -1,0 +1,90 @@
+
+name: logging_status
+label: Capture pattern from Text output
+description: |
+  This example Skillet shows how to use output capturing with text based output. Some PAN-OS commands return a text
+  output instead of XML or JSON structured data. In these cases, you can use 'capture_pattern' to return a the first
+  occurance of a regular expression match. To capture more than one item, you can use the 'capture_list' attribute. This
+  will return all matches from the given regular expression.
+
+type: panos
+labels:
+  collection:
+    - Test Skillets
+
+variables:
+  - name: qos_class
+    description: QoS Class to Check
+    default: class4
+    type_hint: text
+    help_text: Which class to ensure has at least one valid profile configured for it
+
+  - name: child_2_unique_variable
+    description: Random variable unique to another child
+    default: test123456
+    type_hint: text
+
+
+snippets:
+  - name: get_logging_status
+    cmd: cli
+    # This cli command will return a text blob
+    cmd_str: show logging-status
+    output_type: text
+    outputs:
+      # let's capture a variable called 'connected_server_ip'
+      - name: connected_server_ip
+        # this will search the text returned from the cli command and return the first match found using this regex
+        # pattern
+        capture_pattern: is active and connected to (.*)\n
+        # this will capture ALL matches from the following regex as a list. No matches always return an empty list
+      - name: all_cms
+        capture_list: Not Sending to CMS (\d+)
+
+# Example output from the cli is given here for illustrative purposes
+
+# output is:
+# -----------------------------------------------------------------------------------------------------------------------------
+#      Type      Last Log Created        Last Log Fwded       Last Seq Num Fwded  Last Seq Num Acked         Total Logs Fwded
+#-----------------------------------------------------------------------------------------------------------------------------
+#> CMS 0
+#	Not Sending to CMS 0
+#> CMS 1
+#	Not Sending to CMS 1
+#
+#>Log Collection Service
+#'Log Collection log forwarding agent' is active and connected to 1.2.3.4
+#
+#
+#    config         Not Available         Not Available                        0                   0                        0
+#    system         Not Available         Not Available                        0                   0                        0
+#    threat         Not Available         Not Available                        0                   0                        0
+#   traffic   2020/07/15 14:48:00   2020/07/15 14:48:09                       41                  41                       41
+#  hipmatch         Not Available         Not Available                        0                   0                        0
+#gtp-tunnel         Not Available         Not Available                        0                   0                        0
+#    userid         Not Available         Not Available                        0                   0                        0
+#     iptag         Not Available         Not Available                        0                   0                        0
+#      auth         Not Available         Not Available                        0                   0                        0
+#      sctp         Not Available         Not Available                        0                   0                        0
+#   decrypt         Not Available         Not Available                        0                   0                        0
+#globalprotect         Not Available         Not Available                        0                   0                        0
+
+# Snippet execution output will be:
+
+# {
+#    "snippets": {
+#        "get_logging_status": {
+#            "results": "success",
+#            "changed": false
+#        }
+#    },
+#    "outputs": {
+#        "connected_server_ip": "1.2.3.4",
+#        "all_cms": [
+#            "0",
+#            "1"
+#        ]
+#    },
+#    "result": "success",
+#    "changed": false
+# }

--- a/example_skillets/skillet_includes/network_profiles.skillet.yaml
+++ b/example_skillets/skillet_includes/network_profiles.skillet.yaml
@@ -19,6 +19,11 @@ variables:
     default: test123456
     type_hint: text
 
+  - name: shared_base_variable
+    description: Random variable shared with all children skillets
+    default: test_val1
+    type_hint: text
+
 snippets:
   - name: parse_network_profiles
     label: Capturing Profile Values

--- a/example_skillets/skillet_includes/qos_class.skillet.yaml
+++ b/example_skillets/skillet_includes/qos_class.skillet.yaml
@@ -19,16 +19,24 @@ description: |
 type: pan_validation
 labels:
   collection:
-    - Example Skillets
-    - Validation
+    - Test Skillets
 
 variables:
+  - name: shared_base_variable
+    description: Random variable shared with all children skillets
+    default: test_val2
+    type_hint: text
+
   - name: qos_class
     description: QoS Class to Check
     default: class4
     type_hint: text
     help_text: Which class to ensure has at least one valid profile configured for it
 
+  - name: child_1_unique_variable
+    description: Random variable unique to one child
+    default: test123456
+    type_hint: text
 
 snippets:
   - name: qos_parse

--- a/example_skillets/skillet_includes/update_schedule.skillet.yaml
+++ b/example_skillets/skillet_includes/update_schedule.skillet.yaml
@@ -9,6 +9,11 @@ labels:
   collection: Test Skillets
 
 variables:
+  - name: shared_base_variable
+    description: Random variable shared with all children skillets
+    default: test123456
+    type_hint: text
+
   - name: some_update_variable
     description: Random Variable to check
     default: test123456

--- a/skilletlib/skilletLoader.py
+++ b/skilletlib/skilletLoader.py
@@ -57,21 +57,21 @@ class SkilletLoader:
     skillet_errors = list()
 
     # tmp_dir where resolved git repositories will be cloned
-    tmp_dir = '~./.skilletlib'
+    tmp_dir = "~./.skilletlib"
 
     # list of directories to skip and not recurse into
-    skip_dirs = ['.terraform', '.git', '.venv', 'venv', '.idea', '.tox', '.eggs']
+    skip_dirs = [".terraform", ".git", ".venv", "venv", ".idea", ".tox", ".eggs"]
 
     def __init__(self, path=None):
 
         self.skillets = list()
         self.resolved_skillets = list()
 
-        debug = os.environ.get('SKILLET_DEBUG', False)
+        debug = os.environ.get("SKILLET_DEBUG", False)
 
         if debug:
             logger.setLevel(logging.DEBUG)
-            logger.debug('Debugging output enabled')
+            logger.debug("Debugging output enabled")
 
         if path is not None:
             self.load_all_skillets_from_dir(path)
@@ -108,7 +108,7 @@ class SkilletLoader:
 
         if self.__skillet_has_includes(skillet_dict):
             self.__resolve_submodule_skillets(skillet_path_object)
-            self.__resolve_neighbor_skillets(skillet_dict['name'], skillet_path_object)
+            self.__resolve_neighbor_skillets(skillet_dict["name"], skillet_path_object)
 
         compiled_skillet_dict = self.compile_skillet_dict(skillet_dict)
         return self.create_skillet(compiled_skillet_dict)
@@ -120,46 +120,55 @@ class SkilletLoader:
         :param skillet_dict: Dictionary loaded from the skillet.yaml definition file
         :return: Skillet Object
         """
-        skillet_type = skillet_dict['type']
+        skillet_type = skillet_dict["type"]
 
-        if skillet_type == 'panos' or skillet_type == 'panorama' or skillet_type == 'panorama-gpcs':
+        if skillet_type == "panos" or skillet_type == "panorama" or skillet_type == "panorama-gpcs":
             from skilletlib.skillet.panos import PanosSkillet
+
             return PanosSkillet(skillet_dict)
 
-        elif skillet_type == 'pan_validation':
+        elif skillet_type == "pan_validation":
             from skilletlib.skillet.pan_validation import PanValidationSkillet
+
             return PanValidationSkillet(skillet_dict)
 
-        elif skillet_type == 'python3':
+        elif skillet_type == "python3":
             from skilletlib.skillet.python3 import Python3Skillet
+
             return Python3Skillet(skillet_dict)
 
-        elif skillet_type == 'template':
+        elif skillet_type == "template":
             from skilletlib.skillet.template import TemplateSkillet
+
             return TemplateSkillet(skillet_dict)
 
-        elif skillet_type == 'docker':
+        elif skillet_type == "docker":
             from skilletlib.skillet.docker import DockerSkillet
+
             return DockerSkillet(skillet_dict)
 
-        elif skillet_type == 'rest':
+        elif skillet_type == "rest":
             from skilletlib.skillet.rest import RestSkillet
+
             return RestSkillet(skillet_dict)
 
-        elif skillet_type == 'workflow':
+        elif skillet_type == "workflow":
             from skilletlib.skillet.workflow import WorkflowSkillet
+
             return WorkflowSkillet(skillet_dict, self)
 
-        elif skillet_type == 'terraform':
+        elif skillet_type == "terraform":
             from skilletlib.skillet.terraform import TerraformSkillet
+
             return TerraformSkillet(skillet_dict)
 
-        elif skillet_type == 'app':
+        elif skillet_type == "app":
             from skilletlib.skillet.app import AppSkillet
+
             return AppSkillet(skillet_dict)
 
         else:
-            raise SkilletLoaderException(f'Unknown Skillet Type: {skillet_type}!')
+            raise SkilletLoaderException(f"Unknown Skillet Type: {skillet_type}!")
 
     def _parse_skillet(self, path: (str, Path)) -> dict:
         """
@@ -178,60 +187,58 @@ class SkilletLoader:
             path_obj = path
 
         else:
-            raise SkilletLoaderException('Invalid path type found in _parse_skillet!')
+            raise SkilletLoaderException("Invalid path type found in _parse_skillet!")
 
-        if 'meta-cnc' in path_str or 'skillet.y' in path_str:
+        if "meta-cnc" in path_str or "skillet.y" in path_str:
             meta_cnc_file = path_obj
 
             if not path_obj.exists():
-                raise SkilletNotFoundException(f'Could not find skillet.yaml file as this location: {path}')
+                raise SkilletNotFoundException(f"Could not find skillet.yaml file as this location: {path}")
 
         else:
             # we were only passed a directory like '.' or something, try to find a skillet.yaml or .meta-cnc.yml
             directory = path_obj
-            logger.debug(f'using directory {directory}')
+            logger.debug(f"using directory {directory}")
 
             found_files = list()
-            found_files.extend(directory.glob('.meta-cnc.y*'))
-            found_files.extend(directory.glob('*skillet.y*'))
+            found_files.extend(directory.glob(".meta-cnc.y*"))
+            found_files.extend(directory.glob("*skillet.y*"))
 
             if not found_files:
-                raise SkilletNotFoundException('Could not find skillet definition file at this location')
+                raise SkilletNotFoundException("Could not find skillet definition file at this location")
 
             if len(found_files) > 1:
-                logger.warning('Found more than 1 skillet file at this location! Using first file found!')
+                logger.warning("Found more than 1 skillet file at this location! Using first file found!")
 
             meta_cnc_file = found_files[0]
 
         if meta_cnc_file is None:
-            raise SkilletNotFoundException('Could not find skillet definition file at this location')
+            raise SkilletNotFoundException("Could not find skillet definition file at this location")
 
         snippet_path = str(meta_cnc_file.parent.absolute())
         skillet_file = str(meta_cnc_file.name)
 
         try:
 
-            with meta_cnc_file.open(mode='r', encoding='utf-8') as sc:
+            with meta_cnc_file.open(mode="r", encoding="utf-8") as sc:
                 raw_service_config = oyaml.safe_load(sc.read())
                 skillet = self.normalize_skillet_dict(raw_service_config)
-                skillet['snippet_path'] = snippet_path
-                skillet['skillet_path'] = snippet_path
-                skillet['skillet_filename'] = skillet_file
+                skillet["snippet_path"] = snippet_path
+                skillet["skillet_path"] = snippet_path
+                skillet["skillet_filename"] = skillet_file
                 return skillet
 
         except IOError:
-            logger.error('Could not open metadata file in dir %s' % meta_cnc_file.parent)
-            raise SkilletLoaderException('IOError: Could not parse metadata file in dir %s' % meta_cnc_file.parent)
+            logger.error("Could not open metadata file in dir %s" % meta_cnc_file.parent)
+            raise SkilletLoaderException("IOError: Could not parse metadata file in dir %s" % meta_cnc_file.parent)
 
         except YAMLError as ye:
             logger.error(ye)
-            raise SkilletLoaderException(
-                'YAMLError: Could not parse metadata file in dir %s' % meta_cnc_file.parent)
+            raise SkilletLoaderException("YAMLError: Could not parse metadata file in dir %s" % meta_cnc_file.parent)
 
         except Exception as ex:
             logger.error(ex)
-            raise SkilletLoaderException(
-                'Exception: Could not parse metadata file in dir %s' % meta_cnc_file.parent)
+            raise SkilletLoaderException("Exception: Could not parse metadata file in dir %s" % meta_cnc_file.parent)
 
     def __resolve_neighbor_skillets(self, skillet_name: str, skillet_path: Path) -> None:
         """
@@ -247,8 +254,8 @@ class SkilletLoader:
             skillet_path = skillet_path.parent
 
         skillet_definitions = list()
-        skillet_definitions.extend(skillet_path.glob('*.skillet.y*ml'))
-        skillet_definitions.extend(skillet_path.glob('.meta-cnc.y*ml'))
+        skillet_definitions.extend(skillet_path.glob("*.skillet.y*ml"))
+        skillet_definitions.extend(skillet_path.glob(".meta-cnc.y*ml"))
 
         neighbor_skillets = list()
 
@@ -256,22 +263,22 @@ class SkilletLoader:
 
             try:
                 skillet = self.load_skillet_dict_from_path(d)
-                if skillet['name'] != skillet_name:
+                if skillet["name"] != skillet_name:
                     neighbor_skillets.append(skillet)
 
             except SkilletLoaderException as sle:
                 err_dict = dict()
-                err_dict['path'] = str(d.absolute())
-                err_dict['error'] = str(sle)
+                err_dict["path"] = str(d.absolute())
+                err_dict["error"] = str(sle)
                 self.skillet_errors.append(err_dict)
-                logger.warning(f'Loader Error for dir {d.absolute()} - {sle}')
+                logger.warning(f"Loader Error for dir {d.absolute()} - {sle}")
 
             except OSError as oe:
                 err_dict = dict()
-                err_dict['path'] = str(d.absolute())
-                err_dict['error'] = str(oe)
+                err_dict["path"] = str(d.absolute())
+                err_dict["error"] = str(oe)
                 self.skillet_errors.append(err_dict)
-                logger.warning(f'OS Error for dir {d.absolute()} - {oe}')
+                logger.warning(f"OS Error for dir {d.absolute()} - {oe}")
 
         for skillet_dict in neighbor_skillets:
             if not self.__skillet_has_includes(skillet_dict):
@@ -297,7 +304,7 @@ class SkilletLoader:
         all_parents.extend(path.parents)
 
         for p in all_parents:
-            git_dir = p.joinpath('.git')
+            git_dir = p.joinpath(".git")
             if git_dir.exists():
                 git_root = p
                 break
@@ -342,20 +349,21 @@ class SkilletLoader:
         :return: None
         """
 
-        if 'depends' not in skillet:
+        if "depends" not in skillet:
             return None
 
-        depends_list = skillet.get('depends', [])
+        depends_list = skillet.get("depends", [])
         for depends in depends_list:
-            cloned_skillets = self.load_skillet_dicts_from_git(depends['url'], depends['name'], depends['branch'],
-                                                               self.tmp_dir)
+            cloned_skillets = self.load_skillet_dicts_from_git(
+                depends["url"], depends["name"], depends["branch"], self.tmp_dir
+            )
             for cs in cloned_skillets:
                 found_include = False
-                for css in cs['snippets']:
-                    if 'include' in css:
+                for css in cs["snippets"]:
+                    if "include" in css:
                         found_include = True
 
-                if not found_include and 'depends' not in cs:
+                if not found_include and "depends" not in cs:
                     # we do not do recursive dependency resolution. Only index skillets with no dependencies
                     self.resolved_skillets.append(self.create_skillet(cs))
 
@@ -371,8 +379,8 @@ class SkilletLoader:
         :return: boolean True if a snippet with an included skillet is found
         """
 
-        for snippet in skillet_dict.get('snippets', []):
-            if 'include' in snippet:
+        for snippet in skillet_dict.get("snippets", []):
+            if "include" in snippet:
                 return True
 
         return False
@@ -390,19 +398,19 @@ class SkilletLoader:
         # fix for #163 - ensure we use deepcopy to avoid modifying the origin snippet definition
         child_copy = copy.deepcopy(child)
 
-        if 'tags' in parent:
-            if 'tags' not in child_copy:
-                child_copy['tags'] = list()
+        if "tags" in parent:
+            if "tags" not in child_copy:
+                child_copy["tags"] = list()
 
-            child_copy['tags'].extend(parent['tags'])
+            child_copy["tags"].extend(parent["tags"])
 
-        elif 'tag' in parent:
-            if 'tag' not in child_copy:
-                child_copy['tag'] = list()
+        elif "tag" in parent:
+            if "tag" not in child_copy:
+                child_copy["tag"] = list()
 
-            child_copy['tag'].extend(parent['tag'])
+            child_copy["tag"].extend(parent["tag"])
 
-        attributes = ('when', 'label', 'documentation_link', 'description', 'pass_message', 'fail_message')
+        attributes = ("when", "label", "documentation_link", "description", "pass_message", "fail_message")
         for a in attributes:
             if a in parent:
                 child_copy[a] = parent[a]
@@ -419,55 +427,55 @@ class SkilletLoader:
         :return: full compiled skillet definition dictionary
         """
         snippets = list()
-        variables: list = skillet['variables']
-        parent_only_variables = variables.copy()
+        variables: list = skillet["variables"]
+        parent_only_variables: list = variables.copy()
 
-        for snippet in skillet.get('snippets', []):
+        for snippet in skillet.get("snippets", []):
 
-            if 'include' not in snippet:
+            if "include" not in snippet:
                 snippets.append(snippet)
                 continue
 
-            included_skillet: Skillet = self.get_skillet_with_name(snippet['include'], include_resolved_skillets=True)
+            included_skillet: Skillet = self.get_skillet_with_name(snippet["include"], include_resolved_skillets=True)
             if included_skillet is None:
                 raise SkilletLoaderException(f'Could not find included Skillet with name: {snippet["include"]}')
 
-            if 'include_snippets' not in snippet and 'include_variables' not in snippet:
+            if "include_snippets" not in snippet and "include_variables" not in snippet:
                 # include all snippets by default
                 for included_snippet in included_skillet.snippet_stack:
-                    include_snippet_name = included_snippet['name']
+                    include_snippet_name = included_snippet["name"]
                     propagated_snippet = self.__propagate_snippet_metadata(snippet, included_snippet)
 
                     # ensure the name is set properly
-                    propagated_snippet['name'] = f'{included_skillet.name}.{include_snippet_name}'
+                    propagated_snippet["name"] = f"{included_skillet.name}.{include_snippet_name}"
                     snippets.append(propagated_snippet)
 
                 # incorporate every variable into the compiled skillet's variable list
                 for v in included_skillet.variables:
-                    variables = self.update_variable_list(variables, parent_only_variables,
-                                                          v, False)
+                    variables = self.__update_variable_list(variables, parent_only_variables, v, False)
 
-            elif 'include_snippets' not in snippet:
+            elif "include_snippets" not in snippet:
                 # include all snippets by default
                 for included_snippet in included_skillet.snippet_stack:
-                    include_snippet_name = included_snippet['name']
+                    include_snippet_name = included_snippet["name"]
                     included_meta = self.__propagate_snippet_metadata(snippet, included_snippet)
-                    included_meta['name'] = f'{included_skillet.name}.{include_snippet_name}'
+                    included_meta["name"] = f"{included_skillet.name}.{include_snippet_name}"
                     snippets.append(included_meta)
 
             else:
-                for include_snippet in snippet['include_snippets']:
-                    include_snippet_name = include_snippet['name']
+                for include_snippet in snippet["include_snippets"]:
+                    include_snippet_name = include_snippet["name"]
                     include_snippet_object = included_skillet.get_snippet_by_name(include_snippet_name)
                     include_meta = include_snippet_object.metadata
                     # the meta attribute in the metadata is a dict that we do not want to completely overwrite
-                    if 'meta' in include_snippet:
-                        include_snippet_object_meta = include_meta.get('meta', {})
-                        if isinstance(include_snippet_object_meta, dict) and \
-                                isinstance(include_snippet.get('meta', {}), dict):
+                    if "meta" in include_snippet:
+                        include_snippet_object_meta = include_meta.get("meta", {})
+                        if isinstance(include_snippet_object_meta, dict) and isinstance(
+                            include_snippet.get("meta", {}), dict
+                        ):
                             new_meta = include_snippet_object_meta.copy()
-                            new_meta.update(include_snippet.get('meta', {}))
-                            include_snippet['meta'] = new_meta
+                            new_meta.update(include_snippet.get("meta", {}))
+                            include_snippet["meta"] = new_meta
 
                     # propagate everything form the parent if it's there
                     include_meta = self.__propagate_snippet_metadata(snippet, include_meta)
@@ -476,26 +484,25 @@ class SkilletLoader:
                     include_meta.update(include_snippet)
 
                     # ensure the name is set properly
-                    include_meta['name'] = f'{included_skillet.name}.{include_snippet_name}'
+                    include_meta["name"] = f"{included_skillet.name}.{include_snippet_name}"
 
                     snippets.append(include_meta)
 
-            if 'include_variables' in snippet:
-                if isinstance(snippet['include_variables'], str) and snippet['include_variables'] == 'all':
+            if "include_variables" in snippet:
+                if isinstance(snippet["include_variables"], str) and snippet["include_variables"] == "all":
                     # incorporate every variable into the compiled skillet's variable list
                     for v in included_skillet.variables:
-                        variables = self.update_variable_list(variables, parent_only_variables,
-                                                              v, False)
+                        variables = self.__update_variable_list(variables, parent_only_variables, v, False)
 
-                elif isinstance(snippet['include_variables'], list):
+                elif isinstance(snippet["include_variables"], list):
 
                     # handle case where we have a single dict item with name == 'all' to override all snippet attributes
                     # see issue #182 for details
-                    if len(snippet['include_variables']) == 1 and snippet['include_variables'][0]['name'] == 'all':
-                        override_attribute = snippet['include_variables'][0]
+                    if len(snippet["include_variables"]) == 1 and snippet["include_variables"][0]["name"] == "all":
+                        override_attribute = snippet["include_variables"][0]
 
                         for v in included_skillet.variables:
-                            original_name = v['name']
+                            original_name = v["name"]
                             # #163 - always uses deepcopy when using includes / overrides
                             overridden_variable = copy.deepcopy(v)
                             # update this variable definition accordingly if necessary
@@ -503,15 +510,16 @@ class SkilletLoader:
                             # reformat name from 'all' back to original name
                             overridden_variable["name"] = original_name
                             # incorporate variable into compiled list but merge if var exists
-                            variables = self.update_variable_list(variables, parent_only_variables,
-                                                                  overridden_variable, True)
+                            variables = self.__update_variable_list(
+                                variables, parent_only_variables, overridden_variable, True
+                            )
 
                     # handle case where there's a list of variable to include and override
                     else:
-                        for v in snippet['include_variables']:
+                        for v in snippet["include_variables"]:
                             # we need to include only the variables listed here and possibly update them with any
                             # new / modified attributes
-                            included_variable_orig = included_skillet.get_variable_by_name(v['name'])
+                            included_variable_orig = included_skillet.get_variable_by_name(v["name"])
 
                             # #163 - always uses deepcopy when using includes / overrides
                             included_variable = copy.deepcopy(included_variable_orig)
@@ -520,16 +528,18 @@ class SkilletLoader:
 
                             # incorporate variable into compiled list and no merge since in this case the
                             # child variable overrides anything that exists
-                            variables = self.update_variable_list(variables, parent_only_variables,
-                                                                  included_variable, False)
+                            variables = self.__update_variable_list(
+                                variables, parent_only_variables, included_variable, False
+                            )
 
-        skillet['snippets'] = snippets
-        skillet['variables'] = variables
+        skillet["snippets"] = snippets
+        skillet["variables"] = variables
 
         return skillet
 
-    def update_variable_list(self, compiled_variables: list, parent_variables: list, child_variable: dict,
-                             merged: bool) -> list:
+    def __update_variable_list(
+        self, compiled_variables: list, parent_variables: list, child_variable: dict, merged: bool
+    ) -> list:
         """
         Adds the given child skillet's variable into the current compiled skillet's variable list
 
@@ -598,186 +608,206 @@ class SkilletLoader:
         if type(skillet) is not dict:
             skillet = dict()
 
-        if 'name' not in skillet:
-            skillet['name'] = 'Unknown Skillet'
+        if "name" not in skillet:
+            skillet["name"] = "Unknown Skillet"
 
-        if 'label' not in skillet:
-            skillet['label'] = 'Unknown Skillet'
+        if "label" not in skillet:
+            skillet["label"] = "Unknown Skillet"
 
-        if 'type' not in skillet:
-            skillet['type'] = 'template'
+        if "type" not in skillet:
+            skillet["type"] = "template"
 
-        if 'description' not in skillet:
-            skillet['description'] = 'template skillet'
+        if "description" not in skillet:
+            skillet["description"] = "template skillet"
 
         # first verify the variables stanza is present and is a list
-        if 'variables' not in skillet:
-            skillet['variables'] = list()
+        if "variables" not in skillet:
+            skillet["variables"] = list()
 
-        elif skillet['variables'] is None:
-            skillet['variables'] = list()
+        elif skillet["variables"] is None:
+            skillet["variables"] = list()
 
-        elif type(skillet['variables']) is not list:
-            skillet['variables'] = list()
+        elif type(skillet["variables"]) is not list:
+            skillet["variables"] = list()
 
-        elif type(skillet['variables']) is list:
+        elif type(skillet["variables"]) is list:
 
-            for variable in skillet['variables']:
+            for variable in skillet["variables"]:
 
                 if type(variable) is not dict:
-                    logger.debug('Removing Invalid Variable Definition')
-                    skillet['variables'].remove(variable)
+                    logger.debug("Removing Invalid Variable Definition")
+                    skillet["variables"].remove(variable)
 
                 else:
 
-                    if 'name' not in variable:
-                        variable['name'] = 'Unknown variable'
+                    if "name" not in variable:
+                        variable["name"] = "Unknown variable"
 
-                    if 'type_hint' not in variable:
-                        variable['type_hint'] = 'text'
+                    if "type_hint" not in variable:
+                        variable["type_hint"] = "text"
 
-                    if 'default' not in variable:
-                        variable['default'] = ''
+                    if "default" not in variable:
+                        variable["default"] = ""
 
-        if 'depends' not in skillet:
-            skillet['depends'] = list()
+        if "depends" not in skillet:
+            skillet["depends"] = list()
 
-        elif not isinstance(skillet['depends'], list):
-            skillet['depends'] = list()
+        elif not isinstance(skillet["depends"], list):
+            skillet["depends"] = list()
 
-        elif isinstance(skillet['depends'], list):
-            for depends in skillet['depends']:
+        elif isinstance(skillet["depends"], list):
+            for depends in skillet["depends"]:
 
                 if not isinstance(depends, dict):
-                    print('Removing Invalid Depends Definition')
+                    print("Removing Invalid Depends Definition")
                     print(type(depends))
-                    skillet['depends'].remove(depends)
+                    skillet["depends"].remove(depends)
 
                 else:
-                    if not {'url', 'name'}.issubset(depends):
-                        print('Removing Invalid Depends Definition - incorrect attributes')
+                    if not {"url", "name"}.issubset(depends):
+                        print("Removing Invalid Depends Definition - incorrect attributes")
                         print('Required "url" and "name" to be present. "branch" is optional')
                         print(depends)
 
                     else:
-                        if depends['url'] is None or depends['url'] == '' \
-                                or depends['name'] is None or depends['name'] == '':
-                            print('Removing Invalid Depends Definition - incorrect attribute values')
+                        if (
+                            depends["url"] is None
+                            or depends["url"] == ""
+                            or depends["name"] is None
+                            or depends["name"] == ""
+                        ):
+                            print("Removing Invalid Depends Definition - incorrect attribute values")
                             print('Required "url" and "name" to be not be blank or None')
                             print(depends)
 
         # verify labels stanza is present and is a OrderedDict
-        if 'labels' not in skillet:
-            skillet['labels'] = OrderedDict()
+        if "labels" not in skillet:
+            skillet["labels"] = OrderedDict()
 
-        elif skillet['labels'] is None:
-            skillet['labels'] = OrderedDict()
+        elif skillet["labels"] is None:
+            skillet["labels"] = OrderedDict()
 
-        elif type(skillet['labels']) is not OrderedDict and type(skillet['labels']) is not dict:
-            skillet['labels'] = OrderedDict()
+        elif type(skillet["labels"]) is not OrderedDict and type(skillet["labels"]) is not dict:
+            skillet["labels"] = OrderedDict()
 
         # ensure we have a collection label
-        if 'collection' not in skillet['labels'] or type(skillet['labels']['collection']) is None:
+        if "collection" not in skillet["labels"] or type(skillet["labels"]["collection"]) is None:
             # do not force a collection for 'app' type skillets as these aren't meant to be shown to the end user
 
-            if skillet['type'] != 'app':
-                skillet['labels']['collection'] = list()
-                skillet['labels']['collection'].append('Unknown')
+            if skillet["type"] != "app":
+                skillet["labels"]["collection"] = list()
+                skillet["labels"]["collection"].append("Unknown")
 
-        elif type(skillet['labels']['collection']) is str:
+        elif type(skillet["labels"]["collection"]) is str:
             new_collection = list()
-            old_value = skillet['labels']['collection']
+            old_value = skillet["labels"]["collection"]
             new_collection.append(old_value)
-            skillet['labels']['collection'] = new_collection
+            skillet["labels"]["collection"] = new_collection
 
         # ensure no app_data attribute is present in the skillet definition
-        if 'app_data' in skillet:
-            skillet.pop('app_data')
+        if "app_data" in skillet:
+            skillet.pop("app_data")
 
         # verify snippets stanza is present and is a list
-        if 'snippets' not in skillet:
-            skillet['snippets'] = list()
+        if "snippets" not in skillet:
+            skillet["snippets"] = list()
 
-        elif skillet['snippets'] is None:
-            skillet['snippets'] = list()
+        elif skillet["snippets"] is None:
+            skillet["snippets"] = list()
 
-        elif type(skillet['snippets']) is not list:
-            skillet['snippets'] = list()
+        elif type(skillet["snippets"]) is not list:
+            skillet["snippets"] = list()
 
-        for snippet in skillet['snippets']:
+        for snippet in skillet["snippets"]:
             if not isinstance(snippet, dict):
-                skillet['snippets'].remove(snippet)
+                skillet["snippets"].remove(snippet)
 
-            if 'include' in snippet:
-                include_def = snippet['include']
+            if "include" in snippet:
+                include_def = snippet["include"]
 
                 if not isinstance(include_def, str):
-                    skillet['snippets'].remove(snippet)
-                    logger.error(f'{skillet["name"]}: '
-                                 'Removing invalid snippet definition: include is not a str')
+                    skillet["snippets"].remove(snippet)
+                    logger.error(f'{skillet["name"]}: ' "Removing invalid snippet definition: include is not a str")
                     continue
 
-                if 'include_snippets' in snippet:
-                    include_snippets_def = snippet['include_snippets']
+                if "include_snippets" in snippet:
+                    include_snippets_def = snippet["include_snippets"]
                     if not isinstance(include_snippets_def, list):
-                        skillet['snippets'].remove(snippet)
-                        logger.error(f'{skillet["name"]}: Removing invalid snippet definition: include_snippets '
-                                     'is not a list')
+                        skillet["snippets"].remove(snippet)
+                        logger.error(
+                            f'{skillet["name"]}: Removing invalid snippet definition: include_snippets ' "is not a list"
+                        )
                         continue
 
                     for isd in include_snippets_def:
                         if not isinstance(isd, dict):
                             include_snippets_def.remove(isd)
-                            logger.error(f'{skillet["name"]}: Removing invalid include_snippets definition: '
-                                         'include_snippets item is not a dict')
+                            logger.error(
+                                f'{skillet["name"]}: Removing invalid include_snippets definition: '
+                                "include_snippets item is not a dict"
+                            )
                             continue
 
-                        if 'name' not in isd:
+                        if "name" not in isd:
                             include_snippets_def.remove(isd)
-                            logger.error(f'{skillet["name"]}: Removing invalid include_snippets definition: '
-                                         'include_snippets item requires a name attribute')
+                            logger.error(
+                                f'{skillet["name"]}: Removing invalid include_snippets definition: '
+                                "include_snippets item requires a name attribute"
+                            )
                             continue
 
-                if 'include_variables' in snippet:
-                    include_variables_def = snippet['include_variables']
+                if "include_variables" in snippet:
+                    include_variables_def = snippet["include_variables"]
                     if isinstance(include_variables_def, str):
-                        if not include_variables_def == 'all':
-                            skillet['snippets'].remove(snippet)
-                            logger.error(f'{skillet["name"]}: Removing invalid snippet definition: '
-                                         'include_variables must be all or list')
+                        if not include_variables_def == "all":
+                            skillet["snippets"].remove(snippet)
+                            logger.error(
+                                f'{skillet["name"]}: Removing invalid snippet definition: '
+                                "include_variables must be all or list"
+                            )
                             continue
 
                     elif isinstance(include_variables_def, list):
                         for ivd in include_variables_def:
                             if not isinstance(ivd, dict):
                                 include_variables_def.remove(ivd)
-                                logger.error(f'{skillet["name"]}: Removing invalid include_variables definition: '
-                                             'include_variables item is not a dict')
+                                logger.error(
+                                    f'{skillet["name"]}: Removing invalid include_variables definition: '
+                                    "include_variables item is not a dict"
+                                )
                                 continue
 
-                            if 'name' not in ivd:
+                            if "name" not in ivd:
                                 include_variables_def.remove(ivd)
-                                logger.error(f'{skillet["name"]}: Removing invalid include_variables definition: '
-                                             'include_variables item requires a name')
+                                logger.error(
+                                    f'{skillet["name"]}: Removing invalid include_variables definition: '
+                                    "include_variables item requires a name"
+                                )
                                 continue
                     else:
-                        skillet['snippets'].remove(snippet)
-                        logger.error(f'{skillet["name"]}: '
-                                     'Removing invalid snippet definition: include_variables is not a list or all')
+                        skillet["snippets"].remove(snippet)
+                        logger.error(
+                            f'{skillet["name"]}: '
+                            "Removing invalid snippet definition: include_variables is not a list or all"
+                        )
                         continue
 
             else:
 
-                if 'include_snippets' in snippet:
-                    skillet['snippets'].remove(snippet)
-                    logger.error(f'{skillet["name"]}: '
-                                 f'Removing invalid snippet definition: include_snippets requires an include attribute')
+                if "include_snippets" in snippet:
+                    skillet["snippets"].remove(snippet)
+                    logger.error(
+                        f'{skillet["name"]}: '
+                        f"Removing invalid snippet definition: include_snippets requires an include attribute"
+                    )
                     continue
 
-                if 'include_variables' in snippet:
-                    skillet['snippets'].remove(snippet)
-                    logger.error(f'{skillet["name"]}: '
-                                 'Removing invalid snippet definition: include_variables requires an include attribute')
+                if "include_variables" in snippet:
+                    skillet["snippets"].remove(snippet)
+                    logger.error(
+                        f'{skillet["name"]}: '
+                        "Removing invalid snippet definition: include_variables requires an include attribute"
+                    )
                     continue
 
         return skillet
@@ -794,29 +824,40 @@ class SkilletLoader:
         errs = list()
 
         if skillet is None:
-            errs.append('Skillet is blank or could not be loaded')
+            errs.append("Skillet is blank or could not be loaded")
             return errs
 
         if not isinstance(skillet, dict):
-            errs.append('Skillet is malformed')
+            errs.append("Skillet is malformed")
             return errs
 
         # verify labels stanza is present
-        if 'labels' not in skillet:
-            errs.append('No labels attribute present in skillet')
+        if "labels" not in skillet:
+            errs.append("No labels attribute present in skillet")
         else:
-            if 'collection' not in skillet['labels']:
-                errs.append('No collection defined in skillet')
+            if "collection" not in skillet["labels"]:
+                errs.append("No collection defined in skillet")
 
-        if 'label' not in skillet:
-            errs.append('No label attribute in skillet')
+        if "label" not in skillet:
+            errs.append("No label attribute in skillet")
 
-        if 'type' not in skillet:
-            errs.append('No type attribute in skillet')
+        if "type" not in skillet:
+            errs.append("No type attribute in skillet")
         else:
-            valid_types = ['panos', 'panorama', 'panorama-gpcs', 'pan_validation',
-                           'python3', 'rest', 'terraform', 'template', 'workflow', 'docker', 'app']
-            if skillet['type'] not in valid_types:
+            valid_types = [
+                "panos",
+                "panorama",
+                "panorama-gpcs",
+                "pan_validation",
+                "python3",
+                "rest",
+                "terraform",
+                "template",
+                "workflow",
+                "docker",
+                "app",
+            ]
+            if skillet["type"] not in valid_types:
                 errs.append(f'Unknown type {skillet["type"]} in skillet')
 
         return errs
@@ -831,7 +872,7 @@ class SkilletLoader:
         """
 
         if not self.skillets and not self.resolved_skillets:
-            raise SkilletLoaderException('No Skillets have been loaded!')
+            raise SkilletLoaderException("No Skillets have been loaded!")
 
         for skillet in self.skillets:
             if skillet.name == skillet_name:
@@ -878,24 +919,24 @@ class SkilletLoader:
         for skillet_dict in skillet_definitions:
             found_include = False
 
-            for snippet in skillet_dict.get('snippets', []):
-                if 'include' in snippet:
+            for snippet in skillet_dict.get("snippets", []):
+                if "include" in snippet:
                     found_include = True
 
             if not found_include:
                 try:
                     self.skillets.append(self.create_skillet(skillet_dict))
-                    processed_skillets.append(skillet_dict['name'])
+                    processed_skillets.append(skillet_dict["name"])
 
                 except SkilletLoaderException as sle:
                     err_dict = dict()
-                    err_dict['path'] = skillet_dict.get('name', '')
-                    err_dict['error'] = str(sle)
+                    err_dict["path"] = skillet_dict.get("name", "")
+                    err_dict["error"] = str(sle)
                     self.skillet_errors.append(err_dict)
 
         # now resolve deps for those that do inclusions
         for skillet_dict in skillet_definitions:
-            if skillet_dict['name'] in processed_skillets:
+            if skillet_dict["name"] in processed_skillets:
                 continue
 
             # do not yet pull down deps automatically. FIXME - need to signal to skilletlib that this operation is OK
@@ -907,8 +948,8 @@ class SkilletLoader:
 
             except SkilletLoaderException as sle:
                 err_dict = dict()
-                err_dict['path'] = skillet_dict.get('name', '')
-                err_dict['error'] = str(sle)
+                err_dict["path"] = skillet_dict.get("name", "")
+                err_dict["error"] = str(sle)
                 self.skillet_errors.append(err_dict)
 
         return self.skillets
@@ -924,12 +965,12 @@ class SkilletLoader:
         :param skillet_list: combined list of all skillet_dicts
         :return: list of Skillets
         """
-        logger.debug(f'Checking dir: {directory}')
+        logger.debug(f"Checking dir: {directory}")
         err_condition = False
 
         skillet_definitions = list()
-        skillet_definitions.extend(directory.glob('*.skillet.y*ml'))
-        skillet_definitions.extend(directory.glob('.meta-cnc.y*ml'))
+        skillet_definitions.extend(directory.glob("*.skillet.y*ml"))
+        skillet_definitions.extend(directory.glob(".meta-cnc.y*ml"))
 
         for d in skillet_definitions:
 
@@ -938,23 +979,23 @@ class SkilletLoader:
                 skillet_list.append(skillet)
 
             except SkilletNotFoundException:
-                err_condition = f'Skillet not found in dir {d.name}'
+                err_condition = f"Skillet not found in dir {d.name}"
 
             except SkilletLoaderException as sle:
                 # for panhandler gl #19 - keep track of loader errors and associated directory
                 err_dict = dict()
-                err_dict['path'] = str(d.absolute())
-                err_dict['error'] = str(sle)
+                err_dict["path"] = str(d.absolute())
+                err_dict["error"] = str(sle)
                 self.skillet_errors.append(err_dict)
-                err_condition = f'Loader Error for dir {d.absolute()} - {sle}'
+                err_condition = f"Loader Error for dir {d.absolute()} - {sle}"
 
             except OSError as oe:
                 # catch all OSErrors for #117
                 err_dict = dict()
-                err_dict['path'] = str(d.absolute())
-                err_dict['error'] = str(oe)
+                err_dict["path"] = str(d.absolute())
+                err_dict["error"] = str(oe)
                 self.skillet_errors.append(err_dict)
-                err_condition = f'OS Error for dir {d.absolute()} - {oe}'
+                err_condition = f"OS Error for dir {d.absolute()} - {oe}"
 
         if err_condition:
             logger.warning(err_condition)
@@ -981,8 +1022,7 @@ class SkilletLoader:
 
         return skillet_list
 
-    def load_skillets_from_git(self, repo_url, repo_name, repo_branch,
-                               local_dir=None) -> List[Skillet]:
+    def load_skillets_from_git(self, repo_url, repo_name, repo_branch, local_dir=None) -> List[Skillet]:
         """
         Performs a local clone of the given Git repository URL and returns a list of all found skillets defined
         therein.
@@ -1014,8 +1054,7 @@ class SkilletLoader:
         if local_dir is None:
             local_dir = self.tmp_dir
 
-        skillet_definitions = self.load_skillet_dicts_from_git(repo_url, repo_name, repo_branch,
-                                                               local_dir)
+        skillet_definitions = self.load_skillet_dicts_from_git(repo_url, repo_name, repo_branch, local_dir)
 
         skillets = list()
         for skillet_dict in skillet_definitions:
@@ -1023,8 +1062,7 @@ class SkilletLoader:
 
         return skillets
 
-    def load_skillet_dicts_from_git(self, repo_url, repo_name, repo_branch,
-                                    local_dir=None) -> List[dict]:
+    def load_skillet_dicts_from_git(self, repo_url, repo_name, repo_branch, local_dir=None) -> List[dict]:
         """
         Performs a local clone of the given Git repository URL and returns a list of all found skillet definition
         dictionaries defined therein.

--- a/skilletlib/skilletLoader.py
+++ b/skilletlib/skilletLoader.py
@@ -440,21 +440,7 @@ class SkilletLoader:
             if included_skillet is None:
                 raise SkilletLoaderException(f'Could not find included Skillet with name: {snippet["include"]}')
 
-            if "include_snippets" not in snippet and "include_variables" not in snippet:
-                # include all snippets by default
-                for included_snippet in included_skillet.snippet_stack:
-                    include_snippet_name = included_snippet["name"]
-                    propagated_snippet = self.__propagate_snippet_metadata(snippet, included_snippet)
-
-                    # ensure the name is set properly
-                    propagated_snippet["name"] = f"{included_skillet.name}.{include_snippet_name}"
-                    snippets.append(propagated_snippet)
-
-                # incorporate every variable into the compiled skillet's variable list
-                for v in included_skillet.variables:
-                    variables = self.__update_variable_list(variables, parent_only_variables, v, False)
-
-            elif "include_snippets" not in snippet:
+            if "include_snippets" not in snippet:
                 # include all snippets by default
                 for included_snippet in included_skillet.snippet_stack:
                     include_snippet_name = included_snippet["name"]
@@ -488,7 +474,10 @@ class SkilletLoader:
 
                     snippets.append(include_meta)
 
-            if "include_variables" in snippet:
+            if "include_variables" not in snippet:
+                for v in included_skillet.variables:
+                    variables = self.__update_variable_list(variables, parent_only_variables, v, False)
+            else:
                 if isinstance(snippet["include_variables"], str) and snippet["include_variables"] == "all":
                     # incorporate every variable into the compiled skillet's variable list
                     for v in included_skillet.variables:

--- a/tests/test_skillet_include.py
+++ b/tests/test_skillet_include.py
@@ -80,7 +80,6 @@ def test_skillet_includes():
     # verify the child variable is present in compiled skillet
     assert included_snip_only_variable is not None
 
-
     # Check that a snippet of this format is brought in correctly
     #       - name: something
     #         include: child_skillet

--- a/tests/test_skillet_include.py
+++ b/tests/test_skillet_include.py
@@ -43,7 +43,7 @@ def test_skillet_includes():
     assert skillet.name == 'include_other_skillets'
 
     # verify the correct number of snippets.
-    assert len(skillet.snippets) == 13
+    assert len(skillet.snippets) == 14
 
     included_snippet: Snippet = skillet.get_snippet_by_name('network_profiles.check_network_profiles')
 
@@ -67,8 +67,21 @@ def test_skillet_includes():
     another_included_variable: dict = skillet.get_variable_by_name('zone_to_test')
     assert another_included_variable["default"] == "untrust"
 
-    override_from_all_variable: dict = skillet.get_variable_by_name('qos_class')
-    assert override_from_all_variable["toggle_hint"] is not None
+    # verify that shared children variables merge attributes
+    merged_override_from_all_variable: dict = skillet.get_variable_by_name('qos_class')
+    assert merged_override_from_all_variable["toggle_hint"] is not None
+    assert merged_override_from_all_variable["toggle_hint"]["value"] == ["untrust", "internet"]
+
+    # verify that the override variables brought up to the parent are preserved
+    parent_preserve_variable: dict = skillet.get_variable_by_name('shared_base_variable')
+    assert "toggle_hint" not in parent_preserve_variable
+
+    # verify that child override works
+    child_override_1_variable: dict = skillet.get_variable_by_name('child_1_unique_variable')
+    assert child_override_1_variable["toggle_hint"] is not None
+
+    child_override_2_variable: dict = skillet.get_variable_by_name('child_2_unique_variable')
+    assert child_override_2_variable["toggle_hint"] is not None
 
     # Ensure using includes / overrides leaves our original skillet definition intact
     # added for issue #163
@@ -87,7 +100,7 @@ def test_load_skillet_from_path():
     assert skillet.name == 'include_other_skillets'
 
     # verify the correct number of snippets.
-    assert len(skillet.snippets) == 13
+    assert len(skillet.snippets) == 14
 
     included_snippet: Snippet = skillet.get_snippet_by_name('network_profiles.check_network_profiles')
 

--- a/tests/test_skillet_include.py
+++ b/tests/test_skillet_include.py
@@ -70,7 +70,8 @@ def test_skillet_includes():
     # verify that shared children variables merge attributes
     merged_override_from_all_variable: dict = skillet.get_variable_by_name('qos_class')
     assert merged_override_from_all_variable["toggle_hint"] is not None
-    assert merged_override_from_all_variable["toggle_hint"]["value"] == ["untrust", "internet"]
+    assert "internet" in merged_override_from_all_variable["toggle_hint"]["value"]
+    assert "untrust" in merged_override_from_all_variable["toggle_hint"]["value"]
 
     # verify that the override variables brought up to the parent are preserved
     parent_preserve_variable: dict = skillet.get_variable_by_name('shared_base_variable')


### PR DESCRIPTION
## Description

- Implemented a new playlist includes model where any variable inside of the parent skillet gets preserved regardless of duplicates inside of the children skillets 
- Pulled out the duplicate code to append variables to the compiled variables list into its own function called update_variable_list
- Kept track of the original parent variables in a copied list to make sure no variables get added to 
- Commented 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Added a shared_base_variable to all children skillets and to the parent skillet -- its definition in the parent skillet gets preserved
- Added an example_skillet that demonstrates two children adding different toggle_hint values to the same variable
- Added a test case for the parent preserved variable 
- Updated a test case for the toggle_hint merging of two children variables to check that each child's value gets added to the parent's toggle_hint value list
- Updated the example_skillets' collections for easier reference

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
