### PR TITLE
catch RemoteDisconnected in fetch_license

### DIFF
--- a/skilletlib/panoply.py
+++ b/skilletlib/panoply.py
@@ -490,6 +490,10 @@ class Panoply:
                 logger.warning(results)
                 return False
 
+        except RemoteDisconnected:
+            logger.info("PAN-OS dropped the connection due to licensing request")
+            return True
+
         except PanXapiError as pxe:
             # bug present in 9.0.4 that returns content-type of xml but the content is only text.
             # this causes a ParseError to be thrown, however, the operation was actually successful


### PR DESCRIPTION
## Description

It seems to be by design that firewall abruptly disconnects the session when license is fetched. This leads to RemoteDisconnected exception to be raised by the library. This exception is handeled in deactivate_vm_license. 
This pull request makes fetch_license consistent with the behaviour of deactivate_vm_license
