### PR TITLE
Implement python3 snippet execution

### DIFF
--- a/skilletlib/snippet/python3.py
+++ b/skilletlib/snippet/python3.py
@@ -1,3 +1,4 @@
+import subprocess
 from .base import Snippet
 
 
@@ -9,14 +10,14 @@ class Python3Snippet(Snippet):
 
     def execute(self, context):
         """
-        This is a stub function and is NOT currently implemented in skilletlib.
+        Execute a python3 snippet.
 
         :param context: The context used for python3 script execution
         :return: script output and tuple of success / failure
         """
-        if 'python3_output' in context:
-            # this is admittedly a hack to allow python3 skillets to be executed using other means in other tools
-            # but still use output capturing, output_templates, etc from skilletlib. This is def a FIXME item
+        try:
+            p3_exec = subprocess.run(['/usr/bin/env', 'python3', f'{self.skillet.path}/{self.file}'], check=True, capture_output=True)
+            context['python3_output'] = p3_exec.stdout.decode('utf-8')
             return context['python3_output'], 'success'
-
-        return '', 'success'
+        except subprocess.CalledProcessError:
+            return '', 'failure'


### PR DESCRIPTION
## Description

Add a simple routine for execution of python3 snippets. Output is saved also in context in continuity with previous stub.

## Motivation and Context

My goal is to run a workflow skillet, that includes a python3 skillet, using SLI.
 
## How Has This Been Tested?

I've successfully tested the code on my workstation using SLI.

## Checklist

- [ ] I have updated the documentation accordingly. (_is there any docs available for python3 skillets?_)
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate. (_unsure on how to test this code_)
- [x] All new and existing tests passed.
