### PR TITLE
Include hardware appliances (e.g. M-600) in Panorama checks

### DIFF
--- a/skilletlib/panoply.py
+++ b/skilletlib/panoply.py
@@ -764,7 +764,7 @@ class Panoply:
 
         :return: list of zone names
         """
-        if self.facts["model"] != "Panorama":
+        if not self.__is_panorama():
             return self.__get_completion(xpath="/operations/show/zone-protection/zone", completion_type="op")
 
         else:
@@ -779,7 +779,7 @@ class Panoply:
 
         :return: list of security rules
         """
-        if self.facts["model"] != "Panorama":
+        if not self.__is_panorama():
             return self.__get_completion(
                 xpath="/config/devices/entry/vsys/entry/rulebase/security/rules", completion_type="config"
             )
@@ -830,7 +830,7 @@ class Panoply:
         context["DNS_1"] = self.facts["dns-primary"]
         context["DNS_2"] = self.facts["dns-secondary"]
 
-        if self.facts["model"] == "Panorama":
+        if self.__is_panorama():
             skillet_type_dir = "panorama"
 
             if not reset_hostname:
@@ -985,7 +985,7 @@ class Panoply:
                 if self.connected:
 
                     # fix for #60 - show chassis ready is not available on panorama
-                    if self.facts.get("model", "Panorama") == "Panorama":
+                    if self.__is_panorama():
                         cmd = "<show><system><info></info></system></show>"
                         is_panorama = True
                     else:
@@ -1034,7 +1034,7 @@ class Panoply:
         if filter_terms is None:
             filter_terms = {}
 
-        if self.facts.get("model", "") != "Panorama":
+        if not self.__is_panorama():
             logger.info("Method only supported on Panorama Devices")
             return list()
 
@@ -2217,6 +2217,22 @@ class Panoply:
         post_xpaths = ["rulebase"]
 
         return xpaths, post_xpaths
+    
+    def __is_panorama(self) -> bool:
+        """
+        Check the model from system information and returns true if the model is Panorama (virtual or hardware appliance)
+
+        :return: boolean
+        """
+        model = self.facts["model"]
+        if model == "Panorama":
+            # Panorama virtual appliance
+            return True
+        elif model.startswith("M-"):
+            # Panorama hardware appliance (e.g. "M-600")
+            return True
+        else:
+            return False
 
 
 class EphemeralPanos(Panoply):


### PR DESCRIPTION
## Description

I'm proposing this change since Panorama skillets are currently failing when run against Panorama hardware appliances (e.g. M-600).

## Motivation and Context

Panorama checks in panoply.py are based on the **model** value returned from **show system info** API call. On Panorama virtual appliance, model is always _panorama_ so the check end successfully. But on Panorama hardware appliance the model field return the hardware model (M-XXX):

![image](https://github.com/PaloAltoNetworks/skilletlib/assets/562707/8d3f3862-f029-47e5-8bf2-07d611468a9a)

## How Has This Been Tested?

I've tested the change on my own, after that skillets are working when run against hardware appliance.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
